### PR TITLE
Prevent {body} token inheriting

### DIFF
--- a/src/Entities/Template.php
+++ b/src/Entities/Template.php
@@ -68,7 +68,9 @@ class Template extends Entity
 
 		if ($parent = $this->getParent())
 		{
-			$matches[1] = array_unique(array_merge($parent->getTokens(), $matches[1]));
+			// Prepend parent tokens (minus {body})
+			$parentTokens = array_diff($parent->getTokens(), ['body']);
+			$matches[1]   = array_unique(array_merge($parentTokens, $matches[1]));
 		}
 
 		return $matches[1];

--- a/tests/entities/ParentTemplateTest.php
+++ b/tests/entities/ParentTemplateTest.php
@@ -47,7 +47,8 @@ class ParentTemplateTest extends DatabaseTestCase
 
 	public function testChildIncludesParentTokens()
 	{
-		$expected = ['subject', 'body', 'foobar', 'number'];
+		// Notice that {body} is intentionally excluded
+		$expected = ['subject', 'foobar', 'number'];
 		$result   = $this->template->getTokens();
 
 		$this->assertEquals($expected, array_values($result));


### PR DESCRIPTION
When a child template merges tokens from the parent it will now remove `{body}` from the list, since that is removed during render.